### PR TITLE
fix #1584, #1586

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -890,8 +890,12 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Flourish Option", "Includes Flourish in the rotation.", DNC.JobID, 7)]
         DNC_ST_Simple_Flourish = 4056,
 
+        [ParentCombo(DNC_ST_Simple_Flourish)]
+        [CustomComboInfo("Force Triple Weave for alignment", "Forces a triple weave of Flourish and Fan Dance 3 + 4 during non-opener burst windows." + "\nFixes SS/FM drift where you use a gcd when SS/FM is on a 0.5sec CD.", DNC.JobID, 1)]
+        DNC_ST_Simple_Flourish_ForcedTripleWeave = 4088,
+
         [ParentCombo(DNC_ST_SimpleMode)]
-        [CustomComboInfo("Simple Feathers Option", "Expends a feather in the next available weave window when capped." +
+        [CustomComboInfo("Simple Feathers Option", "Expends a feather in the next available weave window when capped and under the effect of Flourishing Symmetry or Flourishing Flow." +
                                                    "\nWeaves feathers where possible during Technical Finish." +
                                                    "\nWeaves feathers outside of burst when target is below set HP percentage (Set to 0 to disable)." +
                                                    "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 8)]
@@ -967,7 +971,7 @@ namespace XIVSlothCombo.Combos
         DNC_AoE_Simple_Flourish = 4076,
 
         [ParentCombo(DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Simple AoE Feathers Option", "Expends a feather in the next available weave window when capped." +
+        [CustomComboInfo("Simple AoE Feathers Option", "Expends a feather in the next available weave window when capped and under the effect of Flourishing Symmetry or Flourishing Flow." +
        "\nWeaves feathers where possible during Technical Finish." +
        "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 7)]
         DNC_AoE_Simple_Feathers = 4077,
@@ -1012,7 +1016,7 @@ namespace XIVSlothCombo.Combos
 
         #endregion
 
-        // Last value = 4086
+        // Last value = 4088
 
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -800,7 +800,7 @@ namespace XIVSlothCombo.Combos.PvE
                 // AoE Saber Dance (Emergency Use)
                 if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) &&
                     LevelChecked(SaberDance) &&
-                    gauge.Esprit >= 80 &&
+                    gauge.Esprit >= 50 &&
                     ActionReady(SaberDance))
                     return SaberDance;
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -425,8 +425,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                             // FD1 Pooling
                             if (gauge.Feathers > 3 &&
-                                (GetCooldownRemainingTime(TechnicalStep) > 2.5f ||
-                                 IsOffCooldown(TechnicalStep)))
+                                (HasEffect(Buffs.SilkenSymmetry) ||
+                                 HasEffect(Buffs.SilkenFlow))
+                                )
+
                                 return FanDance1;
                         }
 
@@ -496,7 +498,7 @@ namespace XIVSlothCombo.Combos.PvE
                 // ST Saber Dance (Emergency Use)
                 if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) &&
                     LevelChecked(SaberDance) &&
-                    gauge.Esprit >= 80 &&
+                    gauge.Esprit >= 50 &&
                     ActionReady(SaberDance))
                     return SaberDance;
 
@@ -564,7 +566,8 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         // ST Fan Dance overcap protection
                         if (IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap) &&
-                            LevelChecked(FanDance1) && gauge.Feathers is 4)
+                            LevelChecked(FanDance1) && gauge.Feathers is 4 && (HasEffect(Buffs.SilkenSymmetry) ||
+                            HasEffect(Buffs.SilkenFlow)))
                             return FanDance1;
 
                         // ST Fan Dance 3/4 on combo
@@ -716,8 +719,8 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 // FD2 Pooling
                                 if (gauge.Feathers > 3 &&
-                                    (GetCooldownRemainingTime(TechnicalStep) > 2.5f ||
-                                     IsOffCooldown(TechnicalStep)))
+                                    (HasEffect(Buffs.SilkenSymmetry) ||
+                                     HasEffect(Buffs.SilkenFlow)))
                                     return FanDance2;
                             }
 
@@ -865,7 +868,8 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         // AoE Fan Dance overcap protection
                         if (IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap) &&
-                            LevelChecked(FanDance2) && gauge.Feathers is 4)
+                            LevelChecked(FanDance2) && gauge.Feathers is 4 && 
+                            (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.SilkenFlow)))
                             return FanDance2;
 
                         // AoE Fan Dance 3/4 on combo

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -385,9 +385,11 @@ namespace XIVSlothCombo.Combos.PvE
                     (HasEffect(Buffs.ThreeFoldFanDance) ||
                      HasEffect(Buffs.FourFoldFanDance)) &&
                      CombatEngageDuration().TotalSeconds > 20 &&
-                     GetBuffRemainingTime(Buffs.TechnicalFinish) <= 17)
+                     HasEffect(Buffs.TechnicalFinish) && 
+                     GetCooldownRemainingTime(Flourish) > 58)
                 {
-                    return HasEffect(Buffs.FourFoldFanDance) ? FanDance4 : FanDance3;
+                    if (HasEffect(Buffs.ThreeFoldFanDance) && CanDelayedWeave(actionID)) return FanDance3; 
+                    else if (HasEffect(Buffs.FourFoldFanDance)) return FanDance4;
                 }
 
                 // ST Interrupt
@@ -509,7 +511,9 @@ namespace XIVSlothCombo.Combos.PvE
                     LevelChecked(SaberDance) &&
                     gauge.Esprit >= 50 &&
                     ActionReady(SaberDance))
-                    return SaberDance;
+                    return LevelChecked(DanceOfTheDawn) && HasEffect(Buffs.DanceOfTheDawnReady)
+                        ? OriginalHook(DanceOfTheDawn)
+                        : SaberDance;
 
                 if (HasEffect(Buffs.FlourishingStarfall))
                     return StarfallDance;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -381,8 +381,17 @@ namespace XIVSlothCombo.Combos.PvE
                      CombatEngageDuration().TotalSeconds > 20))
                     return Flourish;
 
+                if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Flourish_ForcedTripleWeave) &&
+                    (HasEffect(Buffs.ThreeFoldFanDance) ||
+                     HasEffect(Buffs.FourFoldFanDance)) &&
+                     CombatEngageDuration().TotalSeconds > 20 &&
+                     GetBuffRemainingTime(Buffs.TechnicalFinish) <= 17)
+                {
+                    return HasEffect(Buffs.FourFoldFanDance) ? FanDance4 : FanDance3;
+                }
+
                 // ST Interrupt
-                if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Interrupt) &&
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Interrupt) &&
                     CanInterruptEnemy() &&
                     ActionReady(All.HeadGraze) &&
                     !HasEffect(Buffs.TechnicalFinish))


### PR DESCRIPTION
adds extra check for flourishing symmetry/flow before dumping a fan dance stack in simple ST, simple AOE, multi ST, and multi AOE. 

Swaps emergency SD usage in simple combos to >50 esprit. Regular usage can already be configured to this through the slider. 